### PR TITLE
Fix: Enable scrolling for athlete list and investigate count limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                     <button id="toggleAthletesBtn" class="m3-button-tonal w-full font-bold py-2 px-4 rounded-full text-md">Show Athletes</button>
                 </div>
 
-                <div id="athleteListContainer" class="mt-4 flex-grow hidden">
+                <div id="athleteListContainer" class="mt-4 flex-grow hidden overflow-y-auto" style="max-height: 40vh;">
                      <div id="athleteList" class="space-y-2">
                          <p id="loadingAthletes" class="text-gray-400">Set API URL to load athletes.</p>
                      </div>


### PR DESCRIPTION
- I modified the athlete list container to be scrollable by adding `overflow-y: auto` and a `max-height` of `40vh`. This allows you to see all athletes even if the list is long.
- I investigated the reported 3-athlete limit. No client-side restrictions were found in the fetching or rendering logic. The frontend is capable of displaying all athletes returned by the backend. If a limit persists, it is likely enforced by the backend Google Apps Script.